### PR TITLE
Introduce new handlers and improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,17 @@ edition = "2021"
 
 [dependencies]
 ansi-diff = "1.0.0"
+argmap = "1.1.1"
 async-std = "1.10.0"
 cable = { path = "../cable.rs/cable" }
 # TODO: Use git path once high-activity dev cycle is complete.
 cable_core = { path = "../cable.rs/cable_core" }
-argmap = "1.1.1"
-term_size = "0.3.2"
-signal-hook = { version = "0.3.13", features = [ "iterator", "extended-siginfo" ] }
-time-format = "1.1.2"
+env_logger = "0.9.0"
 futures = "0.3.13"
 indoc = "1.0.3"
+log = "0.4.0"
 raw_tty = "0.1.0"
+signal-hook = { version = "0.3.13", features = [ "iterator", "extended-siginfo" ] }
+term_size = "0.3.2"
 terminal-keycode = "1.0.0"
+time-format = "1.1.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,6 +137,33 @@ where
         }
     }
 
+    /// Handle the `/channels` command.
+    ///
+    /// Prints a list of known channels for the active cable instance.
+    async fn channels_handler(&mut self) {
+        if let Some((_address, mut cable)) = self.get_active_cable().await {
+            let mut ui = self.ui.lock().await;
+            if let Ok(channels) = cable.store.get_channels().await {
+                if channels.is_empty() {
+                    ui.write_status("{ no known channels for the active cabal }");
+                } else {
+                    for channel in channels {
+                        ui.write_status(&format!["- {}", channel]);
+                    }
+                }
+                ui.update();
+            }
+        } else {
+            let mut ui = self.ui.lock().await;
+            ui.write_status(&format![
+                "{}{}",
+                "cannot list channels with no active cabal set.",
+                " add a cabal with \"/cabal add\" first",
+            ]);
+            ui.update();
+        }
+    }
+
     /// Handle the `/connect` command.
     ///
     /// Attempts a TCP connection to the given host:port.
@@ -489,6 +516,10 @@ where
             "/cabal" => {
                 self.write_status(line).await;
                 self.cabal_handler(args).await;
+            }
+            "/channels" => {
+                self.write_status(line).await;
+                self.channels_handler().await;
             }
             "/connect" => {
                 self.write_status(line).await;

--- a/src/app.rs
+++ b/src/app.rs
@@ -469,31 +469,24 @@ where
         }
 
         match args.get(0).unwrap().as_str() {
-            "/help" => {
-                self.write_status(line).await;
-                self.help_handler().await;
-            }
-            "/quit" | "/exit" | "/q" => {
-                self.write_status(line).await;
-                self.exit = true;
-            }
-            "/win" | "/w" => {
-                self.win_handler(args).await;
-            }
-            "/join" | "/j" => {
-                self.join_handler(args).await?;
-            }
             "/cabal" => {
                 self.write_status(line).await;
                 self.cabal_handler(args).await;
+            }
+            "/connect" => {
+                self.write_status(line).await;
+                self.connect_handler(args).await;
             }
             "/connections" => {
                 self.write_status(line).await;
                 self.connections_handler().await;
             }
-            "/connect" => {
+            "/help" => {
                 self.write_status(line).await;
-                self.connect_handler(args).await;
+                self.help_handler().await;
+            }
+            "/join" | "/j" => {
+                self.join_handler(args).await?;
             }
             "/leave" => {
                 self.leave_handler(args).await?;
@@ -501,6 +494,13 @@ where
             "/listen" => {
                 self.write_status(line).await;
                 self.listen_handler(args).await;
+            }
+            "/quit" | "/exit" | "/q" => {
+                self.write_status(line).await;
+                self.exit = true;
+            }
+            "/win" | "/w" => {
+                self.win_handler(args).await;
             }
             x => {
                 if x.starts_with('/') {
@@ -511,6 +511,7 @@ where
                 }
             }
         }
+
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use cabin::{app::App, ui};
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 fn main() -> Result<(), Error> {
+    // Initialise the logger.
+    env_logger::init();
+
     // Parse the arguments.
     let (_args, _argv) = argmap::parse(env::args());
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeSet, io::Write};
 
 use async_std::sync::{Arc, Mutex};
-use cable::Channel;
+use cable::{Channel, Topic};
+use log::debug;
 use signal_hook::{
     consts::SIGWINCH,
     iterator::{exfiltrator::WithOrigin, SignalsInfo},
@@ -35,6 +36,8 @@ pub struct Window {
     pub address: Addr,
     /// The channel whose contents the window is displaying.
     pub channel: Channel,
+    /// The channel topic.
+    pub topic: Topic,
     /// The age of the most recent post(s) to be displayed.
     pub time_end: u64,
     /// The total number of posts which may be displayed.
@@ -51,6 +54,7 @@ impl Window {
         Self {
             address,
             channel,
+            topic: String::new(),
             time_end: 0,
             limit: 50,
             lines: BTreeSet::default(),
@@ -69,6 +73,10 @@ impl Window {
         let index = self.line_index;
         self.line_index += 1;
         self.lines.insert((timestamp, index, text.to_string()));
+    }
+
+    pub fn update_topic(&mut self, topic: String) {
+        self.topic = topic;
     }
 }
 
@@ -197,18 +205,23 @@ impl Ui {
             self.diff
                 .update(&format![
                     "[{}] {}\n{}\n> {}",
+                    // Display the channel name (!status or other).
                     if window.channel == "!status" {
                         window.channel.to_string()
                     } else {
                         format!["#{}", &window.channel]
                     },
+                    // Display the active cabal address.
                     if window.channel == "!status" && self.active_address.is_some() {
                         let addr = self.active_address.as_ref().unwrap();
                         format!["cabal://{}", hex::to(addr)]
                     } else if window.channel == "!status" {
                         "".to_string()
                     } else {
-                        format!["cabal://{}", hex::to(&window.address)]
+                        debug!("Printing updated topic: {:?}", &window.topic);
+                        //format!["cabal://{}", hex::to(&window.address)]
+                        // Display the channel topic.
+                        format!["{}", &window.topic]
                     },
                     lines.join("\n"),
                     &input,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -221,7 +221,7 @@ impl Ui {
                         debug!("Printing updated topic: {:?}", &window.topic);
                         //format!["cabal://{}", hex::to(&window.address)]
                         // Display the channel topic.
-                        format!["{}", &window.topic]
+                        window.topic.to_string()
                     },
                     lines.join("\n"),
                     &input,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -150,6 +150,12 @@ impl Ui {
             .find(|w| &w.address == address && &w.channel == channel)
     }
 
+    pub fn get_window_index(&self, address: &Addr, channel: &Channel) -> Option<usize> {
+        self.windows
+            .iter()
+            .position(|w| &w.address == address && &w.channel == channel)
+    }
+
     pub fn move_window(&mut self, src: usize, dst: usize) {
         let w = self.windows.remove(src);
         self.windows.insert(dst, w);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -170,6 +170,7 @@ impl Ui {
 
     pub fn update(&mut self) {
         // Get the active window.
+        // TODO: Handle the error case properly.
         let window = self.windows.get(self.active_window).unwrap();
 
         let mut lines = window


### PR DESCRIPTION
This PR introduces many new handlers to aid in interactively testing the `cable.rs` implementation. Logging has also been added to aid in debugging. Several bug fixes are included.

New handlers:

```
/channels
/delete
/leave
/members
/nick
/topic
/whoami
```