### PR TITLE
Add abort feature for display posts task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use std::{env, io};
 
 use async_std::task;
+use cable::Channel;
 use cable_core::MemoryStore;
+use futures::channel::mpsc;
 use raw_tty::IntoRawMode;
 
 use cabin::{app::App, ui};
@@ -18,16 +20,22 @@ fn main() -> Result<(), Error> {
     // Launch the application, resize the UI to match the terminal dimensions
     // and accept input via stdin.
     task::block_on(async move {
+        let (close_channel_sender, close_channel_receiver) = mpsc::unbounded::<Channel>();
+
         let mut app = App::new(
             ui::get_term_size(),
             Box::new(|_name| Box::<MemoryStore>::default()),
+            close_channel_sender,
         );
 
         let ui = app.ui.clone();
         task::spawn(async move { ui::resizer(ui).await });
 
-        app.run(Box::new(io::stdin().into_raw_mode().unwrap()))
-            .await?;
+        app.run(
+            Box::new(io::stdin().into_raw_mode().unwrap()),
+            close_channel_receiver,
+        )
+        .await?;
 
         Ok(())
     })


### PR DESCRIPTION
This solves a bug whereby duplicate posts would be printed to the UI if a channel was joined, left and then later rejoined.

The cause of the bug was an async task, spawned in the join handler, which updates the UI with incoming posts for the given channel. The detached task was not stopped when a channel was left, meaning that a second one would be spawned for the same channel if it was later rejoined.

This PR introduces new code which spawns the task as an abortable future, adds the handle and channel name to a `HashMap` and runs a background listener which receives messages from the leave handler and aborts the task if the channel name matches. I'm really happy with the solution; this was my first time using abortable futures.