### PR TITLE
Display nick or key for each text line

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -403,7 +403,7 @@ where
                         {
                             nick
                         } else {
-                            hex::to(&public_key[..8])
+                            hex::to(&public_key[..4])
                         };
 
                         if let PostBody::Text { channel, text } = post.body {


### PR DESCRIPTION
Lookup the nick for the author of a text post, defaulting to the first 4 hex-encoded characters of the public key if none is found, and insert that into the line to be displayed in the UI.