### PR TITLE
Update time handlers

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -1,13 +1,28 @@
+//! Time-related helper functions.
+
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use cable::Error;
 use time_format::TimeStamp;
 
 /// Return the current system time in seconds since the Unix epoch.
-pub fn now() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
+pub fn now() -> Result<u64, Error> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_millis()
+        .try_into()?;
+
+    Ok(now)
+}
+
+/// Return the time defining two weeks before the current system time.
+///
+/// Used to calculate the start time for channel time range
+/// requests.
+pub fn two_weeks_ago() -> Result<u64, Error> {
+    let two_weeks_ago = now()? - 1_209_600_000;
+
+    Ok(two_weeks_ago)
 }
 
 /// Format seconds since the Unix epoch as a timestamp with hour and minutes.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -64,7 +64,7 @@ impl Window {
 
     /// Write the message to the window.
     pub fn write(&mut self, msg: &str) {
-        self.insert(time::now(), None, msg);
+        self.insert(time::now().unwrap(), None, msg);
     }
 
     /// Insert a new line into the window using the given message timestamp,


### PR DESCRIPTION
This PR uses milliseconds instead of seconds for timestamps and introduces helper functions (ie. `two_weeks_ago()`).

There is also some minor code clean-up.