### PR TITLE
Introduce colours

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "0.9.0"
 futures = "0.3.13"
 indoc = "1.0.3"
 log = "0.4.0"
+owo-colors = "3.5.0"
 raw_tty = "0.1.0"
 signal-hook = { version = "0.3.13", features = [ "iterator", "extended-siginfo" ] }
 term_size = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ mod hex;
 pub mod input;
 mod time;
 pub mod ui;
+mod utils;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,29 @@
+use owo_colors::AnsiColors;
+
+fn pick_colour(num: u64) -> AnsiColors {
+    match num {
+        1 => AnsiColors::Red,
+        2 => AnsiColors::Green,
+        3 => AnsiColors::Yellow,
+        4 => AnsiColors::Blue,
+        5 => AnsiColors::Magenta,
+        6 => AnsiColors::Cyan,
+        7 => AnsiColors::BrightRed,
+        8 => AnsiColors::BrightGreen,
+        9 => AnsiColors::BrightYellow,
+        10 => AnsiColors::BrightBlue,
+        11 => AnsiColors::BrightMagenta,
+        12 => AnsiColors::BrightCyan,
+        _ => AnsiColors::White,
+    }
+}
+
+/// Pick a colour based on the sum of the base16 digits comprising
+/// the given public key.
+pub fn public_key_to_colour(public_key: &[u8; 32]) -> AnsiColors {
+    // A return type of `u64` is used to avoid the overflow which will
+    // likely occur if returning `u8`.
+    let sum: u64 = public_key.iter().map(|x| *x as u64).sum();
+
+    pick_colour(sum % 12)
+}


### PR DESCRIPTION
This PR adds the [owo-colors](https://crates.io/crates/owo-colors) crate to enable printing text with colours.

Inspired by [cabal-cli/neat-screen.js](https://github.com/cabal-club/cabal-cli/blob/master/neat-screen.js), I have added a deterministic colour picker for public keys. Only ANSI colours are used for now but this could be expanded in the future to allow for more unique colours.

`!status` is now printed in bright green and the public key / nickname of each poster is printed in colour. 

In the future, it may be desirable to implement colours using ANSI colour escape sequences in `cabin` - thus removing the need for an external dependency.